### PR TITLE
Add multi-page vanilla HTML/CSS/JS site

### DIFF
--- a/vanilla/about.html
+++ b/vanilla/about.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Estética Bella - Nosotros</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <h1 class="logo">Estética Bella</h1>
+    <nav>
+      <ul class="nav-links">
+        <li><a href="index.html">Inicio</a></li>
+        <li><a href="services.html">Servicios</a></li>
+        <li><a href="about.html">Nosotros</a></li>
+        <li><a href="contact.html">Contacto</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="about">
+      <h2>Sobre Nosotros</h2>
+      <p>Somos un salón de belleza con más de 3 años ofreciendo servicios
+         profesionales y personalizados. Nuestro equipo está comprometido
+         con resaltar tu belleza natural.</p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; 2024 Estética Bella. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/vanilla/app.js
+++ b/vanilla/app.js
@@ -1,0 +1,83 @@
+const services = [
+  {
+    name: 'Uñas Acrílicas Naturales',
+    category: 'uñas',
+    description: 'Set natural con forma almendra, acabado duradero.',
+    price: 450
+  },
+  {
+    name: 'Maquillaje para Evento',
+    category: 'maquillaje',
+    description: 'Look de larga duración y piel luminosa.',
+    price: 700
+  },
+  {
+    name: 'Peinado Recogido Elegante',
+    category: 'peinado',
+    description: 'Recogido pulcro y sofisticado para eventos.',
+    price: 550
+  },
+  {
+    name: 'Corte de Cabello Caballero',
+    category: 'cortecolor',
+    description: 'Corte clásico o fade moderno adaptado a tu estilo.',
+    price: 200
+  },
+  {
+    name: 'Manicure Express',
+    category: 'uñas',
+    description: 'Manicure rápido y pulcro para el día a día.',
+    price: 180
+  },
+  {
+    name: 'Tratamiento Capilar',
+    category: 'tratamientos',
+    description: 'Hidratación profunda con productos nutritivos.',
+    price: 300
+  }
+];
+
+const listEl = document.getElementById('service-list');
+if (listEl) {
+  const filterButtons = document.querySelectorAll('.filter-btn');
+
+  function renderServices(filter = 'todos') {
+    listEl.innerHTML = '';
+    services
+      .filter(s => filter === 'todos' || s.category === filter)
+      .forEach(s => {
+        const card = document.createElement('div');
+        card.className = 'service-card';
+        card.innerHTML = `
+          <h3>${s.name}</h3>
+          <p>${s.description}</p>
+          <p><strong>$${s.price}</strong></p>
+        `;
+        listEl.appendChild(card);
+      });
+  }
+
+  filterButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      filterButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      renderServices(btn.dataset.category);
+    });
+  });
+
+  renderServices();
+}
+
+const form = document.getElementById('contact-form');
+if (form) {
+  const statusEl = document.getElementById('form-status');
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    statusEl.textContent = 'Enviando...';
+    setTimeout(() => {
+      statusEl.textContent = '¡Gracias! Nos pondremos en contacto pronto.';
+      form.reset();
+    }, 1000);
+  });
+}
+

--- a/vanilla/contact.html
+++ b/vanilla/contact.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Estética Bella - Contacto</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <h1 class="logo">Estética Bella</h1>
+    <nav>
+      <ul class="nav-links">
+        <li><a href="index.html">Inicio</a></li>
+        <li><a href="services.html">Servicios</a></li>
+        <li><a href="about.html">Nosotros</a></li>
+        <li><a href="contact.html">Contacto</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="contact">
+      <h2>Contacto</h2>
+      <p>Teléfono: <a href="tel:+525512345567">+52 55 1234 5567</a></p>
+      <p>Dirección: Av. Revolución 123, Col. Centro, CDMX</p>
+      <form id="contact-form" class="contact-form">
+        <input type="text" id="name" placeholder="Tu nombre" required />
+        <input type="email" id="email" placeholder="Tu correo" required />
+        <textarea id="message" placeholder="Mensaje" required></textarea>
+        <button type="submit" class="btn">Enviar</button>
+      </form>
+      <div id="form-status" class="form-status" aria-live="polite"></div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; 2024 Estética Bella. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/vanilla/index.html
+++ b/vanilla/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Estética Bella - Inicio</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <h1 class="logo">Estética Bella</h1>
+    <nav>
+      <ul class="nav-links">
+        <li><a href="index.html">Inicio</a></li>
+        <li><a href="services.html">Servicios</a></li>
+        <li><a href="about.html">Nosotros</a></li>
+        <li><a href="contact.html">Contacto</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="hero">
+      <h2>Tu belleza, nuestra pasión</h2>
+      <p>Servicios profesionales para resaltar tu estilo.</p>
+      <a class="btn" href="https://wa.me/525512345567" target="_blank">Reserva por WhatsApp</a>
+    </section>
+
+    <section class="services">
+      <h2>Servicios</h2>
+      <div class="filters">
+        <button class="filter-btn active" data-category="todos">Todos</button>
+        <button class="filter-btn" data-category="uñas">Uñas</button>
+        <button class="filter-btn" data-category="maquillaje">Maquillaje</button>
+        <button class="filter-btn" data-category="peinado">Peinado</button>
+        <button class="filter-btn" data-category="cortecolor">Corte y Color</button>
+        <button class="filter-btn" data-category="tratamientos">Tratamientos</button>
+      </div>
+      <div id="service-list" class="service-list"></div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; 2024 Estética Bella. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/vanilla/services.html
+++ b/vanilla/services.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Estética Bella - Servicios</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="navbar">
+    <h1 class="logo">Estética Bella</h1>
+    <nav>
+      <ul class="nav-links">
+        <li><a href="index.html">Inicio</a></li>
+        <li><a href="services.html">Servicios</a></li>
+        <li><a href="about.html">Nosotros</a></li>
+        <li><a href="contact.html">Contacto</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section class="services">
+      <h2>Todos los Servicios</h2>
+      <div class="filters">
+        <button class="filter-btn active" data-category="todos">Todos</button>
+        <button class="filter-btn" data-category="uñas">Uñas</button>
+        <button class="filter-btn" data-category="maquillaje">Maquillaje</button>
+        <button class="filter-btn" data-category="peinado">Peinado</button>
+        <button class="filter-btn" data-category="cortecolor">Corte y Color</button>
+        <button class="filter-btn" data-category="tratamientos">Tratamientos</button>
+      </div>
+      <div id="service-list" class="service-list"></div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>&copy; 2024 Estética Bella. Todos los derechos reservados.</p>
+  </footer>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/vanilla/styles.css
+++ b/vanilla/styles.css
@@ -1,0 +1,130 @@
+:root {
+  --primary: #7c3aed;
+  --secondary: #f3e8ff;
+  --accent: #ede9fe;
+  --neutral: #6b7280;
+  --background: #f8fafc;
+  --max-width: 960px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: Inter, sans-serif;
+  line-height: 1.5;
+  background: var(--background);
+  color: var(--neutral);
+}
+
+.navbar {
+  background: var(--primary);
+  color: white;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+}
+
+.nav-links a {
+  color: white;
+  text-decoration: none;
+}
+
+.hero {
+  text-align: center;
+  padding: 4rem 1rem;
+  background: var(--secondary);
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 1rem;
+  background: var(--primary);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  text-decoration: none;
+}
+
+main {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.services h2,
+.about h2,
+.contact h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.filters {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  background: var(--accent);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: var(--primary);
+}
+
+.filter-btn.active {
+  background: var(--primary);
+  color: white;
+}
+
+.service-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.service-card {
+  background: white;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.5rem;
+  border: 1px solid var(--neutral);
+  border-radius: 0.25rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem;
+  background: var(--accent);
+  margin-top: 2rem;
+}
+.form-status {
+  margin-top: 0.5rem;
+  font-weight: 500;
+}


### PR DESCRIPTION
## Summary
- expand vanilla site into multiple standalone pages (home, services, about, contact) with shared navigation
- extend service data and filtering logic and conditionally initialize features per page
- style contact form status messages

## Testing
- `npm run lint` *(fails: ui/textarea.tsx no-empty-object-type, tailwind.config.ts no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b66c3238f48325b4d3f9cc6fab7f33