### PR TITLE
Show all services in featured list

### DIFF
--- a/src/components/FeaturedServices.tsx
+++ b/src/components/FeaturedServices.tsx
@@ -2,7 +2,7 @@ import { services } from '@/data/services';
 import ServiceCard from './ServiceCard';
 
 const FeaturedServices = () => {
-  const featuredServices = services.slice(0, 4);
+  const featuredServices = services;
 
   const handleReservar = (serviceId: string) => {
     const service = services.find(s => s.id === serviceId);


### PR DESCRIPTION
## Summary
- remove the slice that limited the featured services component to the first four entries so all defined services are shown on the home page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5827efb44832590df7757e69ac33d